### PR TITLE
Identity: Fix export of publicKeys to Json

### DIFF
--- a/src/main/kotlin/org/dashevo/dpp/identity/Identity.kt
+++ b/src/main/kotlin/org/dashevo/dpp/identity/Identity.kt
@@ -31,7 +31,7 @@ class Identity(var id: String,
     override fun toJSON(): Map<String, Any> {
         return mapOf(
             "id" to id,
-            "publicKeys" to publicKeys,
+            "publicKeys" to publicKeys.map { it.toJSON() },
             "balance" to balance
         )
     }

--- a/src/test/kotlin/org/dashevo/dpp/identity/IdentityTest.kt
+++ b/src/test/kotlin/org/dashevo/dpp/identity/IdentityTest.kt
@@ -145,4 +145,15 @@ class IdentityTest {
         assertEquals("A6AJAfRJyKuNoNvt33ygYfYh6OIYA8tF1s2BQcRA9RNg", identityST.publicKeys[0].data)
         assertTrue(identityST.verifySignatureByPublicKey(ECKey.fromPublicOnly(HashUtils.byteArrayFromString(identityST.publicKeys[0].data))))
     }
+
+    @Test
+    fun identityRoundTrip() {
+        val fromFixture = Fixtures.getIdentityFixture()
+
+        val serialized = fromFixture.serialize()
+
+        val fromSerialized = IdentityFactory().createFromSerialized(serialized);
+
+        assertEquals(fromFixture.toJSON(), fromSerialized.toJSON())
+    }
 }


### PR DESCRIPTION
This will fix the bug of the incorrect export of public keys to Json format.  This bug results in the incorrect cbor serialization of Identity objects.  Those objects cannot be deserialized.

A round trip test is included in this PR.