### PR TITLE
BaseObject:  Add equals and hashCode

### DIFF
--- a/src/main/kotlin/org/dashevo/dpp/BaseObject.kt
+++ b/src/main/kotlin/org/dashevo/dpp/BaseObject.kt
@@ -6,6 +6,7 @@
  */
 package org.dashevo.dpp
 
+import org.bitcoinj.core.Sha256Hash
 import org.dashevo.dpp.util.Cbor
 import org.dashevo.dpp.util.HashUtils
 
@@ -42,5 +43,18 @@ abstract class BaseObject {
      */
     open fun hash(): ByteArray {
         return HashUtils.toHash(toBuffer())
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BaseObject
+
+        return hash().contentEquals(other.hash())
+    }
+
+    override fun hashCode(): Int {
+        return Sha256Hash.wrap(hash()).hashCode()
     }
 }


### PR DESCRIPTION
Add methods to allow Sets and Maps to function properly.

Equality of objects will be by default based on the hash value of the serialized data.